### PR TITLE
Allow a block to be passed to zero-clipboard component

### DIFF
--- a/app/templates/components/zero-clipboard.hbs
+++ b/app/templates/components/zero-clipboard.hbs
@@ -1,1 +1,5 @@
-<button class="{{innerClass}}">{{label}}</button>
+{{#if template}}
+  {{yield}}
+{{else}}
+  <button class="{{innerClass}}">{{label}}</button>
+{{/if}}


### PR DESCRIPTION
I've added support for a block within the `zero-clipboard` component since I wanted to use it in different forms. Sometimes a button, sometimes an image.

```js
{{#zero-clipboard text='Hello'}}
  <p>COPY ME!</p>
{{/zero-clipboard}}
```